### PR TITLE
Fixed columns rules on OgoneAlias entity

### DIFF
--- a/Entity/OgoneAlias.php
+++ b/Entity/OgoneAlias.php
@@ -72,14 +72,14 @@ class OgoneAlias
     /**
      * @var boolean
      *
-     * @ORM\Column(name="operation", type="boolean", nullable=false)
+     * @ORM\Column(name="operation", type="string", length=255, nullable=false)
      */
     private $operation;
 
     /**
      * @var boolean
      *
-     * @ORM\Column(name="status", type="boolean", nullable=false)
+     * @ORM\Column(name="status", type="string", length=255, nullable=false)
      */
     private $status;
 


### PR DESCRIPTION
This fixes wrong columns' definition in OgoneAlias entity

'operation' and 'status' columns expect a string value as defined in the constants of the entity
For now they are defined as expecting boolean values.
