### PR TITLE
Update bundle dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
         }
     ],
     "require": {
-        "symfony/symfony": ">=2.1.0",
-        "doctrine/orm": ">=2.2.3,<2.4-dev",
-        "doctrine/doctrine-bundle": "1.2.*",
+        "symfony/symfony": "~2.1",
+        "doctrine/orm": "~2.2",
+        "doctrine/doctrine-bundle": "~1.2",
         "kriswallsmith/buzz": "v0.10"
     },
     "require-dev": {


### PR DESCRIPTION
Hi @pilot,

Currently when trying to install the bundle with Symfony 2.7 we got this error:

```
  Problem 1
    - Installation request for pilot/ogone-payment-bundle dev-master@dev -> satisfiable by pilot/ogone-payment-bundle[dev-master].
    - pilot/ogone-payment-bundle dev-master requires doctrine/doctrine-bundle 1.2.* -> no matching package found.
```

What do you think about update the dependencies like that?
